### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Builder
+FROM node:14-buster as builder
+
+WORKDIR /src
+
+COPY . /src
+
+RUN npm install --legacy-peer-deps
+
+RUN npm run build
+
+# App
+FROM nginx:alpine
+
+COPY --from=builder /src/out /app
+
+RUN rm -rf /usr/share/nginx/html \
+  && ln -s /app /usr/share/nginx/html

--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ JSON Visio is data visualization tool for your json data which seamlessly illust
   <img width="800" src="https://github.com/AykutSarac/jsonvisio.com/blob/main/public/preview_2.png" alt="preview 1" />
   </div>
 
+## Docker
+
+A Docker file is provided in the root of the repo.
+If you want to run JsonVision locally:
+
+* Build Docker image with `docker build -t jsonvisio.`
+* Run locally with `docker run -p 8888:80 jsonvisio`
+* Go to [http://localhost:8888]
+
 ## 🛠 Development Setup
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ JSON Visio is data visualization tool for your json data which seamlessly illust
 A Docker file is provided in the root of the repo.
 If you want to run JsonVision locally:
 
-* Build Docker image with `docker build -t jsonvisio.`
+* Build Docker image with `docker build -t jsonvisio .`
 * Run locally with `docker run -p 8888:80 jsonvisio`
 * Go to [http://localhost:8888]
 

--- a/README.md
+++ b/README.md
@@ -52,22 +52,25 @@ JSON Visio is data visualization tool for your json data which seamlessly illust
 
 <div align="center">
   <img width="800" src="https://github.com/AykutSarac/jsonvisio.com/blob/main/public/preview_2.png" alt="preview 1" />
-  </div>
+</div>
 
-## Docker
-
-A Docker file is provided in the root of the repo.
-If you want to run JsonVision locally:
-
-* Build Docker image with `docker build -t jsonvisio .`
-* Run locally with `docker run -p 8888:80 jsonvisio`
-* Go to [http://localhost:8888]
 
 ## 🛠 Development Setup
 
-```sh
+```console
   npm install --legacy-peer-deps
   npm run dev
+```
+  
+## 🐳 Docker
+
+```
+A Docker file is provided in the root of the repository.
+If you want to run JSON Visio locally:
+  
+* Build Docker image with `docker build -t jsonvisio .`
+* Run locally with `docker run -p 8888:80 jsonvisio`
+* Go to [http://localhost:8888]
 ```
 
 ## License


### PR DESCRIPTION
Add a simple Dockerfile to allow people running JsonVisio using Docker.
Later this Dockerfile could be used in a GitHub action to provide and official Docker image.