### PR TITLE
fix: handle `/editor` path for nginx

### DIFF
--- a/.nginx/nginx.conf
+++ b/.nginx/nginx.conf
@@ -1,0 +1,15 @@
+worker_processes 4;
+
+events { worker_connections 1024; }
+
+http {
+    server {
+        listen 80;
+        root  /usr/share/nginx/html;
+        include /etc/nginx/mime.types;
+
+        location /editor {
+            try_files $uri /editor.html;
+        }
+    }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,14 @@ WORKDIR /src
 
 COPY . /src
 
-RUN npm install --legacy-peer-deps
+RUN yarn install
 
-RUN npm run build
+RUN yarn run build
 
 # App
 FROM nginx:alpine
+
+COPY ./.nginx/nginx.conf /etc/nginx/nginx.conf
 
 COPY --from=builder /src/out /app
 


### PR DESCRIPTION
I changed package manager `npm` to `yarn` because I've got an error when building the image with docker.

```bash
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type undefined
```
So It's fixed when I use `yarn` . There is no installation step for yarn because the `node:14-buster` image already contains it. 

I'm new to Nginx. Maybe it can be solved in a better way

 Fixes #67