### PR TITLE
fix: added nullsafe operator to patch home error

### DIFF
--- a/src/components/Sponsors/index.tsx
+++ b/src/components/Sponsors/index.tsx
@@ -79,7 +79,7 @@ export const Sponsors = () => {
     }
   }, []);
 
-  if (!sponsors?.users.length) return null;
+  if (!sponsors?.users?.length) return null;
 
   return (
     <StyledSponsorsWrapper>


### PR DESCRIPTION
I am experiencing an issue visiting the page jsonvisio.com using firefox developer edition 104.0b6. It appears the initialization to display the sponsors.users array on useConfig.tsx introduced on commit `ae667d4a3b6db200055bfd5401c704aef39784f5` with message log `add sponsors section` is failing for this firefox edition. This is the screenshot.

![image](https://user-images.githubusercontent.com/3003032/183332015-4793fb21-1388-4629-9e96-9cafc229fb76.png)

Error log on console:

```
TypeError: can't access property "length", e.users is undefined
    NextJS 10
_app-386553644f916d14.js:1:29310

```

```
TypeError: can't access property "length", e.users is undefined
    NextJS 10
_app-386553644f916d14.js:1:29310

```
![image](https://user-images.githubusercontent.com/3003032/183332654-49704de9-a78b-4e3a-a8f1-fcb295b5c9cd.png)

I copied only the relevant error messages. When reproducing on my local main branch, I found the error was on the line I'm changing on this commit.

After creating this patch, I visited jsonvisio.com using firefox 103.0.1 version, and it works. I think this is an issue while loading the default data for sponsors in the latest firefox edition. After putting some debug lines on my local machine, and revert my changes, the issue was gone. This is patch, because I am adding a nullsafe operator to an object attribute that should be initialized as an empty array. When debugging the issue, I found the value of sponsors was:

```
sponsors = {}
```

Expected:
```
{
  "users": [],
  "nextDate": 1660014720690
}
```