### PR TITLE
fix hide wrong collapsed nodes

### DIFF
--- a/src/components/Graph/index.tsx
+++ b/src/components/Graph/index.tsx
@@ -133,8 +133,8 @@ export const Graph = ({ isWidget = false }: { isWidget?: boolean }) => {
   const collapsedEdges = useGraph((state) => state.collapsedEdges);
 
   React.useEffect(() => {
-    const nodeList = collapsedNodes.map((id) => `[id*="node-${id}"]`);
-    const edgeList = collapsedEdges.map((id) => `[class*="edge-${id}"]`);
+    const nodeList = collapsedNodes.map((id) => `[id$="node-${id}"]`);
+    const edgeList = collapsedEdges.map((id) => `[class$="edge-${id}"]`);
 
     const hiddenItems = document.querySelectorAll(".hide");
     hiddenItems.forEach((item) => item.classList.remove("hide"));


### PR DESCRIPTION
When I collapse a node of id from 1 to 10 in a big json the others nodes is hidden. if I collapse id 3, will be collapsed ids, 30, 31, 32... 300. It is because that selector `id*=` select all that includes in beginning or end, But if use the selector `id$=` will only select the end of the`id=`. To know more click [here](https://stackoverflow.com/a/56328426/19669907).
![image](https://user-images.githubusercontent.com/52288843/187293167-9650523f-f5be-4746-a3df-100019f229df.png)

